### PR TITLE
Explicitly close socket after response has entered finished state

### DIFF
--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -189,8 +189,16 @@ void AsyncWebServerRequest::_removeNotInterestingHeaders(){
 
 void AsyncWebServerRequest::_onPoll(){
   //os_printf("p\n");
-  if(_response != NULL && _client != NULL && _client->canSend() && !_response->_finished()){
-    _response->_ack(this, 0, 0);
+  if(_response != NULL && _client != NULL && _client->canSend()){
+    if(!_response->_finished()){
+      _response->_ack(this, 0, 0);
+    } else {
+      AsyncWebServerResponse* r = _response;
+      _response = NULL;
+      delete r;
+
+      _client->close();
+    }
   }
 }
 
@@ -199,10 +207,13 @@ void AsyncWebServerRequest::_onAck(size_t len, uint32_t time){
   if(_response != NULL){
     if(!_response->_finished()){
       _response->_ack(this, len, time);
-    } else {
+    }
+    if(_response->_finished()){
       AsyncWebServerResponse* r = _response;
       _response = NULL;
       delete r;
+
+      _client->close();
     }
   }
 }


### PR DESCRIPTION
In at least two places in the code, the response object is evaluated
on whether it has finished sending data to the client. If the response
has already finished, or enters the finished state after sending data,
the underlying socket should not be left open. Failure to close the
socket in these scenarios cause the remote client to timeout expecting
more data unless it closes the connection on its own.

Fixes: #802